### PR TITLE
Upgrade to version v0.3.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/fmtlib/fmt.git
 [submodule "third_party/autoconf-archive"]
 	path = third_party/autoconf-archive
-	url = git://git.sv.gnu.org/autoconf-archive.git
+	url = https://github.com/autoconf-archive/autoconf-archive.git

--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AC_CONFIG_SRCDIR([include/simple_logger/simple_logger.hpp])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIRS([third_party/autoconf-archive/m4])
 
-AM_INIT_AUTOMAKE([foreign subdir-objects])
+AM_INIT_AUTOMAKE([foreign subdir-objects tar-pax])
 
 AX_CXX_COMPILE_STDCXX_17([noext], [mandatory])
 CXXFLAGS=""


### PR DESCRIPTION
## What's new

+ Fix - Replace the old [`v7` format](https://www.gnu.org/software/tar/manual/tar.html#Formats) with `pax` format to [break the limitation that the length of path of files should be no more than 99 characters](https://stackoverflow.com/a/78984538/15204768)
+ Change - Update the git repository url of submodule `autoreconf-archive`  to the [GitHub mirror](https://github.com/autoconf-archive/autoconf-archive.git) since the original url (git://git.sv.gnu.org/autoconf-archive.git) becomes invalid
