### PR TITLE
Upgrade to version v0.3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0.0)
 project(simple_logger
-    VERSION 0.3.0
+    VERSION 0.3.1
     LANGUAGES CXX
     DESCRIPTION "A simple, multifunctional and header-only log library for C++17"
     HOMEPAGE_URL "https://github.com/Timothy-Liuxf/simple_logger"

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_INIT([simple_logger], [0.3.0], [liuxf19@163.com], [simple_logger],        dnl
+AC_INIT([simple_logger], [0.3.1], [liuxf19@163.com], [simple_logger],        dnl
     [https://github.com/Timothy-Liuxf/simple_logger])
 AC_CONFIG_SRCDIR([include/simple_logger/simple_logger.hpp])
 AC_CONFIG_HEADERS([config.h])


### PR DESCRIPTION
## What's new

+ Fix - Replace the old [`v7` format](https://www.gnu.org/software/tar/manual/tar.html#Formats) with `pax` format to [break the limitation that the length of path of files should be no more than 99 characters](https://stackoverflow.com/a/78984538/15204768)
+ Change - Update the git repository url of submodule `autoreconf-archive`  to the [GitHub mirror](https://github.com/autoconf-archive/autoconf-archive.git) since the original url (git://git.sv.gnu.org/autoconf-archive.git) becomes invalid
